### PR TITLE
Cobrar presentacion sin diferencia de paciente

### DIFF
--- a/src/js/presentaciones/cobrar-presentacion/api.js
+++ b/src/js/presentaciones/cobrar-presentacion/api.js
@@ -14,7 +14,9 @@ export function cobrarPresentacion(idPresentacion, estudios, nroRecibo, retencio
             id: estudio.id,
             importe_cobrado_pension: estudio.pension,
             importe_cobrado_arancel_anestesia: estudio.arancel_anestesia,
-            importe_estudio_cobrado: estudio.importe_estudio,
+            importe_estudio_cobrado:
+                parseFloat(estudio.importe_estudio, 10) -
+                parseFloat(estudio.diferencia_paciente, 10),
             importe_medicacion_cobrado: estudio.importe_medicacion,
         })),
         retencion_impositiva: retencionImpositiva,

--- a/src/js/presentaciones/cobrar-presentacion/cobrarPresentacionReducer.js
+++ b/src/js/presentaciones/cobrar-presentacion/cobrarPresentacionReducer.js
@@ -26,7 +26,6 @@ const fetchDatosDeUnaPresentacionSuccess = (state, action) => sumarImportesEstud
     id: action.id,
     importesOriginales: action.presentacion.estudios.map(estudio => ({
         importe_estudio: estudio.importe_estudio || 0,
-        diferencia_paciente: estudio.diferencia_paciente || 0,
         arancel_anestesia: estudio.arancel_anestesia || 0,
         pension: estudio.pension || 0,
     })),
@@ -47,7 +46,6 @@ const descontarAEstudios = (state, action) => {
             ...estudio,
             actualizarImportes: true,
             importe_estudio: Math.round(estudio.importe_estudio * porcentaje * 100) / 100,
-            diferencia_paciente: Math.round(estudio.diferencia_paciente * porcentaje * 100) / 100,
             arancel_anestesia: Math.round(estudio.arancel_anestesia * porcentaje * 100) / 100,
             pension: Math.round(estudio.pension * porcentaje * 100) / 100,
         })),


### PR DESCRIPTION
# Cobrar presentacion sin diferencia de paciente

## Contexto

La diferencia de paciente es cuando en un estudio, como una obra social paga poco se le cobra al paciente una diferencia. Esa diferencia se tiene que descontar del estudio cuando se crea una presentacion (lo cual, ya estaba hecho). Cuando se da de cobro, no se estaba descontando esa diferencia.

Importe estudio: Importe con la diferencia
Importe para las presentaciones: Importe estudio - importe diferencia

## Cambios en esta PR

 - Se descuenta la diferencia del paciente en cobrar presentacion.

## Estado de la PR

Faltaria eliminar la columna para que el usuario no la pueda ver, pero eso cuando VUELVA DE VACACIONES SI PUEDE SER.
De momento, funca.