### PR TITLE
Caja arreglar errores

### DIFF
--- a/src/js/caja/cajaEpic.js
+++ b/src/js/caja/cajaEpic.js
@@ -26,7 +26,11 @@ export function crearMovimientosCajaEpic(action$) {
         .mergeMap(action =>
             crearMovimientos(action.movimientos)
             .mergeMap(data => Rx.Observable.of(
-                { type: CREATE_MOVIMIENTOS_CAJA_SUCCESS, data, volver: action.goBack() },
+                {
+                    type: CREATE_MOVIMIENTOS_CAJA_SUCCESS,
+                    data, volver: action.goBack(),
+                    destruirForm: action.destruirForm(),
+                },
                 { type: ADD_ALERT, alert: createAlert('Movimientos creados correctamente') },
             ))
             .catch(data => Rx.Observable.of(

--- a/src/js/caja/cajaEpic.js
+++ b/src/js/caja/cajaEpic.js
@@ -63,6 +63,7 @@ export function updateMovimientosCajaEpic(action$) {
                     closeModal: action.setModal(false),
                 },
                 { type: ADD_ALERT, alert: createAlert('Movimiento modificado correctamente') },
+                { type: FETCH_MONTOS_ACUMULADOS },
             ))
             .catch(data => Rx.Observable.of(
                 { type: UPDATE_MOVIMIENTO_CAJA_FAILED, closeModal: action.setModal(false) },

--- a/src/js/caja/cajaReducer.js
+++ b/src/js/caja/cajaReducer.js
@@ -40,59 +40,22 @@ const asociarEstudio = (state, action) => ({
 });
 
 const updateMovimientoCajaSuccess = (state, action) => {
-    let tipoOld;
-    let monto;
-    const getMontosUpdate = (tipoMovimiento, montoMovimiento, tipoNew) => {
-        let montoGeneral = Number(state.montoGeneral);
-        let montoConsultorio1 = Number(state.montoConsultorio1);
-        let montoConsultorio2 = Number(state.montoConsultorio2);
+    const tipo = tiposMovimiento.find(tipoMov =>
+        tipoMov.value === Number(action.datos.tipo));
 
-        if (tipoNew === 9) {
-            montoConsultorio1 += montoMovimiento;
-        } else if (tipoNew === 12) {
-            montoConsultorio2 += montoMovimiento;
-        } else {
-            montoGeneral += montoMovimiento;
-        }
-
-        if (tipoMovimiento === 9) {
-            montoConsultorio1 -= montoMovimiento;
-        } else if (tipoMovimiento === 12) {
-            montoConsultorio2 -= montoMovimiento;
-        } else {
-            montoGeneral -= montoMovimiento;
-        }
-
-        montoGeneral = montoGeneral.toString();
-        montoConsultorio1 = montoConsultorio1.toString();
-        montoConsultorio2 = montoConsultorio2.toString();
-        return { montoGeneral, montoConsultorio1, montoConsultorio2 };
+    const newMovimiento = {
+        medico: action.datos.medico.length > 0 ? action.datos.medico[0] : {},
+        tipo: { id: tipo.value, descripcion: tipo.text },
+        concepto: action.datos.concepto,
     };
 
     return {
         ...state,
-        movimientos: state.movimientos.map((movimiento) => {
-            if (movimiento.id !== action.datos.id) {
-                return movimiento;
-            }
-            const tipo = tiposMovimiento.find(tipoMov =>
-                tipoMov.value === Number(action.datos.tipo));
-
-            monto = movimiento.monto;
-            tipoOld = movimiento.tipo.id;
-
-            return {
-                ...movimiento,
-                medico: action.datos.medico.length > 0 ? action.datos.medico[0] : {},
-                tipo: {
-                    id: tipo.value,
-                    descripcion: tipo.text,
-                },
-                concepto: action.datos.concepto,
-            };
-        }),
         apiLoading: false,
-        ...getMontosUpdate(tipoOld, Number(monto), Number(action.datos.tipo)),
+        movimientos: state.movimientos.map(movimiento => (movimiento.id !== action.datos.id
+            ? movimiento
+            : { ...movimiento, ...newMovimiento }),
+        ),
     };
 };
 

--- a/src/js/caja/cajaReducer.js
+++ b/src/js/caja/cajaReducer.js
@@ -6,6 +6,7 @@ import { FETCH_MOVIMIENTOS_CAJA, LOAD_MOVIMIENTOS_CAJA_SUCCESS,
     FETCH_MONTOS_ACUMULADOS_SUCCESS, UPDATE_MOVIMIENTO_CAJA, UPDATE_MOVIMIENTO_CAJA_FAILED,
     UPDATE_MOVIMIENTO_CAJA_SUCCESS } from './actionTypes';
 import { tiposMovimiento } from '../utilities/generalUtilities';
+import { round } from '../utilities/utilFunctions';
 
 const PAGE_SIZE = 100;
 
@@ -100,6 +101,12 @@ const fetchMontosAcumuladosSuccess = (state, action) => ({
     montoConsultorio1: action.montos.consultorio_1,
     montoConsultorio2: action.montos.consultorio_2,
     montoGeneral: action.montos.general,
+    montoTotal: (
+                round(
+                Number(action.montos.consultorio_1) +
+                Number(action.montos.consultorio_2) +
+                Number(action.montos.general))
+                ).toString(),
     apiLoading: false,
 });
 
@@ -108,6 +115,7 @@ const fetchMontosAcumuladosFailed = state => ({
     montoConsultorio1: '0',
     montoConsultorio2: '0',
     montoGeneral: '0',
+    montoTotal: '0',
     apiLoading: false,
 });
 

--- a/src/js/caja/cajaReducer.js
+++ b/src/js/caja/cajaReducer.js
@@ -38,26 +38,62 @@ const asociarEstudio = (state, action) => ({
     estudioAsociado: action.estudio,
 });
 
-const updateMovimientoCajaSuccess = (state, action) => ({
-    ...state,
-    movimientos: state.movimientos.map((movimiento) => {
-        if (movimiento.id !== action.datos.id) {
-            return movimiento;
-        }
-        const tipo = tiposMovimiento.find(tipoMov => tipoMov.value === Number(action.datos.tipo));
+const updateMovimientoCajaSuccess = (state, action) => {
+    let tipoOld;
+    let monto;
+    const getMontosUpdate = (tipoMovimiento, montoMovimiento, tipoNew) => {
+        let montoGeneral = Number(state.montoGeneral);
+        let montoConsultorio1 = Number(state.montoConsultorio1);
+        let montoConsultorio2 = Number(state.montoConsultorio2);
 
-        return {
-            ...movimiento,
-            medico: action.datos.medico.length > 0 ? action.datos.medico[0] : {},
-            tipo: {
-                id: tipo.value,
-                descripcion: tipo.text,
-            },
-            concepto: action.datos.concepto,
-        };
-    }),
-    apiLoading: false,
-});
+        if (tipoNew === 9) {
+            montoConsultorio1 += montoMovimiento;
+        } else if (tipoNew === 12) {
+            montoConsultorio2 += montoMovimiento;
+        } else {
+            montoGeneral += montoMovimiento;
+        }
+
+        if (tipoMovimiento === 9) {
+            montoConsultorio1 -= montoMovimiento;
+        } else if (tipoMovimiento === 12) {
+            montoConsultorio2 -= montoMovimiento;
+        } else {
+            montoGeneral -= montoMovimiento;
+        }
+
+        montoGeneral = montoGeneral.toString();
+        montoConsultorio1 = montoConsultorio1.toString();
+        montoConsultorio2 = montoConsultorio2.toString();
+        return { montoGeneral, montoConsultorio1, montoConsultorio2 };
+    };
+
+    return {
+        ...state,
+        movimientos: state.movimientos.map((movimiento) => {
+            if (movimiento.id !== action.datos.id) {
+                return movimiento;
+            }
+            const tipo = tiposMovimiento.find(tipoMov =>
+                tipoMov.value === Number(action.datos.tipo));
+
+            monto = movimiento.monto;
+            tipoOld = movimiento.tipo.id;
+
+            return {
+                ...movimiento,
+                medico: action.datos.medico.length > 0 ? action.datos.medico[0] : {},
+                tipo: {
+                    id: tipo.value,
+                    descripcion: tipo.text,
+                },
+                concepto: action.datos.concepto,
+            };
+        }),
+        apiLoading: false,
+        ...getMontosUpdate(tipoOld, Number(monto), Number(action.datos.tipo)),
+    };
+};
 
 const fetchMontosAcumuladosSuccess = (state, action) => ({
     ...state,

--- a/src/js/caja/cajaReducerInitialState.js
+++ b/src/js/caja/cajaReducerInitialState.js
@@ -7,6 +7,7 @@ const initialState = {
     montoConsultorio1: '0',
     montoConsultorio2: '0',
     montoGeneral: '0',
+    montoTotal: '0',
 };
 
 export default initialState;

--- a/src/js/caja/components/CajaActionBar.js
+++ b/src/js/caja/components/CajaActionBar.js
@@ -5,7 +5,6 @@ import { Button, Col, Row } from 'react-bootstrap/dist/react-bootstrap';
 import MontosAcumulados from './MontosAcumulados';
 import { querystring } from '../api';
 import { config } from '../../app/config';
-import { round } from '../../utilities/utilFunctions';
 
 function CajaActionBar({
     openSearchCajaModal,
@@ -14,14 +13,12 @@ function CajaActionBar({
     montoConsultorio1,
     montoConsultorio2,
     montoGeneral,
+    montoTotal,
     searchParams,
 }) {
-    const montoTotal = round(montoConsultorio1 + montoConsultorio2 + montoGeneral);
-    const location = {
-        pathname: '/caja/create',
-        state: { montoAcumulado: montoTotal },
-    };
+    const location = { pathname: '/caja/create' };
     const createMovimientos = () => history.push(location);
+
     return (
         <Row style={ { marginBottom: '3rem' } }>
             <Col md={ 7 }>
@@ -58,24 +55,26 @@ function CajaActionBar({
     );
 }
 
-const { func, object, bool, number } = PropTypes;
+const { func, object, bool, string } = PropTypes;
 
 CajaActionBar.propTypes = {
     openSearchCajaModal: func.isRequired,
     history: object.isRequired,
     apiLoading: bool.isRequired,
-    montoConsultorio1: number.isRequired,
-    montoConsultorio2: number.isRequired,
-    montoGeneral: number.isRequired,
+    montoConsultorio1: string.isRequired,
+    montoConsultorio2: string.isRequired,
+    montoGeneral: string.isRequired,
+    montoTotal: string.isRequired,
     searchParams: object.isRequired,
 };
 
 function mapStateToProps(state) {
     return {
         apiLoading: state.cajaReducer.apiLoading,
-        montoConsultorio1: Number(state.cajaReducer.montoConsultorio1),
-        montoConsultorio2: Number(state.cajaReducer.montoConsultorio2),
-        montoGeneral: Number(state.cajaReducer.montoGeneral),
+        montoConsultorio1: state.cajaReducer.montoConsultorio1,
+        montoConsultorio2: state.cajaReducer.montoConsultorio2,
+        montoGeneral: state.cajaReducer.montoGeneral,
+        montoTotal: state.cajaReducer.montoTotal,
     };
 }
 

--- a/src/js/caja/components/CajaMain.js
+++ b/src/js/caja/components/CajaMain.js
@@ -2,6 +2,7 @@ import React, { useState, useEffect } from 'react';
 import { connect } from 'react-redux';
 import propTypes from 'prop-types';
 import { formValueSelector, change } from 'redux-form';
+import { isEmpty } from 'lodash';
 
 import CajaActionBar from './CajaActionBar';
 import SearchCajaModal from './search/SearchCajaModal';
@@ -24,7 +25,11 @@ function CajaMain({
         update('fechaDesde', initialValues.fechaDesde);
         update('fechaHasta', initialValues.fechaHasta);
 
-        fetchMovimientosCaja(searchParams);
+        if (!isEmpty(searchParams)) {
+            fetchMovimientosCaja(searchParams);
+        } else {
+            fetchMovimientosCaja(initialValues);
+        }
     }, []);
 
     return (

--- a/src/js/caja/components/CajaMain.js
+++ b/src/js/caja/components/CajaMain.js
@@ -17,13 +17,13 @@ function CajaMain({
     history,
     searchParams,
     pageNumber,
-    update,
+    updateForm,
 }) {
     const [modalOpened, setModalOpened] = useState(false);
 
     useEffect(() => {
-        update('fechaDesde', initialValues.fechaDesde);
-        update('fechaHasta', initialValues.fechaHasta);
+        updateForm('fechaDesde', initialValues.fechaDesde);
+        updateForm('fechaHasta', initialValues.fechaHasta);
 
         if (!isEmpty(searchParams)) {
             fetchMovimientosCaja(searchParams);
@@ -56,7 +56,7 @@ function CajaMain({
 const { array, func, object, number } = propTypes;
 
 CajaMain.propTypes = {
-    update: func.isRequired,
+    updateForm: func.isRequired,
     fetchMovimientosCaja: func.isRequired,
     history: object.isRequired,
     searchParams: object.isRequired,
@@ -81,7 +81,7 @@ function mapDispatchToProps(dispatch) {
     return {
         fetchMovimientosCaja: (searchParams, pageNumber = 1) =>
             dispatch({ type: FETCH_MOVIMIENTOS_CAJA, searchParams, pageNumber }),
-        update: (name, value) => dispatch(change('searchCaja', name, value)),
+        updateForm: (name, value) => dispatch(change('searchCaja', name, value)),
     };
 }
 

--- a/src/js/caja/components/CajaMain.js
+++ b/src/js/caja/components/CajaMain.js
@@ -1,8 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { connect } from 'react-redux';
 import propTypes from 'prop-types';
-import { formValueSelector } from 'redux-form';
-import { isEmpty } from 'lodash';
+import { formValueSelector, change } from 'redux-form';
 
 import CajaActionBar from './CajaActionBar';
 import SearchCajaModal from './search/SearchCajaModal';
@@ -17,15 +16,15 @@ function CajaMain({
     history,
     searchParams,
     pageNumber,
+    update,
 }) {
     const [modalOpened, setModalOpened] = useState(false);
 
     useEffect(() => {
-        if (!isEmpty(searchParams)) {
-            fetchMovimientosCaja(searchParams);
-        } else {
-            fetchMovimientosCaja(initialValues);
-        }
+        update('fechaDesde', initialValues.fechaDesde);
+        update('fechaHasta', initialValues.fechaHasta);
+
+        fetchMovimientosCaja(searchParams);
     }, []);
 
     return (
@@ -52,11 +51,12 @@ function CajaMain({
 const { array, func, object, number } = propTypes;
 
 CajaMain.propTypes = {
-    movimientos: array.isRequired,
+    update: func.isRequired,
     fetchMovimientosCaja: func.isRequired,
     history: object.isRequired,
     searchParams: object.isRequired,
     pageNumber: number.isRequired,
+    movimientos: array.isRequired,
 };
 
 const selector = formValueSelector('searchCaja');
@@ -76,6 +76,7 @@ function mapDispatchToProps(dispatch) {
     return {
         fetchMovimientosCaja: (searchParams, pageNumber = 1) =>
             dispatch({ type: FETCH_MOVIMIENTOS_CAJA, searchParams, pageNumber }),
+        update: (name, value) => dispatch(change('searchCaja', name, value)),
     };
 }
 

--- a/src/js/caja/components/ListadoMovimientosTableRow.js
+++ b/src/js/caja/components/ListadoMovimientosTableRow.js
@@ -16,7 +16,6 @@ function ListadoMovimientosTableRow({
     const obraSocial = estudio ? estudio.obra_social.nombre : '-';
     const username = user || '-';
     const medicoName = medico && medico.nombre ? `${medico.apellido}, ${medico.nombre}` : '-';
-    // hace falta preguntar por medico.nombre?
     return (
         <tr>
             <td>{fecha} - {hora}</td>

--- a/src/js/caja/components/ListadoMovimientosTableRow.js
+++ b/src/js/caja/components/ListadoMovimientosTableRow.js
@@ -15,14 +15,8 @@ function ListadoMovimientosTableRow({
     const practica = estudio ? estudio.practica.descripcion : '-';
     const obraSocial = estudio ? estudio.obra_social.nombre : '-';
     const username = user || '-';
-
-    const getNombreMedico = () => {
-        if (medico && medico.nombre) {
-            return `${medico.apellido}, ${medico.nombre}`;
-        }
-        return estudio ? `${estudio.medico.apellido}, ${estudio.medico.nombre}` : '-';
-    };
-
+    const medicoName = medico && medico.nombre ? `${medico.apellido}, ${medico.nombre}` : '-';
+    // hace falta preguntar por medico.nombre?
     return (
         <tr>
             <td>{fecha} - {hora}</td>
@@ -34,7 +28,7 @@ function ListadoMovimientosTableRow({
             <td>{obraSocial}</td>
             <td>{practica}</td>
             <td>{nombrePaciente}</td>
-            <td>{getNombreMedico()}</td>
+            <td>{medicoName}</td>
             { !fromUpdate &&
                 <td>
                     <Button

--- a/src/js/caja/components/MontosAcumulados.js
+++ b/src/js/caja/components/MontosAcumulados.js
@@ -37,14 +37,14 @@ function MontosAcumulados({ fetchMontosAcumulados, consultorio1, consultorio2, g
     );
 }
 
-const { func, number } = PropTypes;
+const { func, string } = PropTypes;
 
 MontosAcumulados.propTypes = {
     fetchMontosAcumulados: func.isRequired,
-    consultorio1: number.isRequired,
-    consultorio2: number.isRequired,
-    general: number.isRequired,
-    total: number.isRequired,
+    consultorio1: string.isRequired,
+    consultorio2: string.isRequired,
+    general: string.isRequired,
+    total: string.isRequired,
 };
 
 function mapDispatchToProps(dispatch) {

--- a/src/js/caja/components/create/BotonesForm.js
+++ b/src/js/caja/components/create/BotonesForm.js
@@ -3,7 +3,6 @@ import PropTypes from 'prop-types';
 import { Button, ButtonToolbar } from 'react-bootstrap';
 
 function BotonesForm({
-    valid,
     selectEstudio,
     estudioAsociado,
     asociarEstudio,
@@ -14,7 +13,6 @@ function BotonesForm({
             <Button
               type='submit'
               bsStyle='primary'
-              disabled={ !valid }
             >
                 Crear Movimientos
             </Button>
@@ -33,10 +31,9 @@ function BotonesForm({
     );
 }
 
-const { func, object, bool } = PropTypes;
+const { func, object } = PropTypes;
 
 BotonesForm.propTypes = {
-    valid: bool.isRequired,
     selectEstudio: func.isRequired,
     estudioAsociado: object.isRequired,
     asociarEstudio: func.isRequired,

--- a/src/js/caja/components/create/CreateCajaForm.js
+++ b/src/js/caja/components/create/CreateCajaForm.js
@@ -5,12 +5,12 @@ import { Form, reduxForm, FieldArray, destroy } from 'redux-form';
 import CreateMovimientosForm from './CreateMovimientosForm';
 import { CREATE_MOVIMIENTOS_CAJA, ASOCIAR_ESTUDIO } from '../../actionTypes';
 import HeaderCreateMovimientoCaja from './HeaderCreateMovimientoCaja';
+import { tiposMovimiento } from '../../../utilities/generalUtilities';
 
 function CreateCajaForm({
     createMovimiento,
     handleSubmit,
     history,
-    valid,
     estudioAsociado,
     asociarEstudio,
     destruirForm,
@@ -27,21 +27,6 @@ function CreateCajaForm({
 
     const selectEstudio = () => history.push(fromCajaLocation);
 
-    const tiposMovimiento = [
-        { text: 'General', value: 1 },
-        { text: 'Honorario Médico', value: 2 },
-        { text: 'Honorario Anestesista', value: 3 },
-        { text: 'Medicación', value: 4 },
-        { text: 'Práctica', value: 5 },
-        { text: 'Descartable', value: 6 },
-        { text: 'Material Específico', value: 7 },
-        { text: 'Pago a Médico', value: 8 },
-        { text: 'Consultorio 1', value: 9 },
-        { text: 'Coseguro', value: 10 },
-        { text: 'Egreso', value: 11 },
-        { text: 'Consultorio 2', value: 12 },
-    ];
-
     const enviarFormulario = movimientos => createMovimiento({
         estudioAsociado,
         movimientos: movimientos.filter(movimiento => (movimiento.monto)).map(movimiento => ({
@@ -50,18 +35,16 @@ function CreateCajaForm({
                 tipo.text === movimiento.tipoMovimiento),
             medico: movimiento.medico ? movimiento.medico[0] : '',
         })),
-    }, history.goBack);
+    }, history.goBack, destruirForm);
 
     return (
         <Form
           onSubmit={ handleSubmit((movimientos) => {
               enviarFormulario(movimientos.movimientos);
-              destruirForm();
           }) }
         >
             <HeaderCreateMovimientoCaja
               selectEstudio={ selectEstudio }
-              valid={ valid }
               asociarEstudio={ asociarEstudio }
               estudioAsociado={ estudioAsociado }
               montoAcumulado={ montoAcumulado }
@@ -77,13 +60,12 @@ function CreateCajaForm({
     );
 }
 
-const { func, object, bool } = PropTypes;
+const { func, object } = PropTypes;
 
 CreateCajaForm.propTypes = {
     createMovimiento: func.isRequired,
     handleSubmit: func.isRequired,
     history: object.isRequired,
-    valid: bool.isRequired,
     estudioAsociado: object.isRequired,
     asociarEstudio: func.isRequired,
     location: object.isRequired,
@@ -104,8 +86,8 @@ function mapStateToProps(state) {
 
 function mapDispatchToProps(dispatch) {
     return {
-        createMovimiento: (movimientos, goBack) =>
-            dispatch({ type: CREATE_MOVIMIENTOS_CAJA, movimientos, goBack }),
+        createMovimiento: (movimientos, goBack, destruirForm) =>
+            dispatch({ type: CREATE_MOVIMIENTOS_CAJA, movimientos, goBack, destruirForm }),
         asociarEstudio: estudio => dispatch({ type: ASOCIAR_ESTUDIO, estudio }),
         destruirForm: () => dispatch(destroy('CreateCajaFormRedux')),
     };

--- a/src/js/caja/components/create/CreateCajaForm.js
+++ b/src/js/caja/components/create/CreateCajaForm.js
@@ -20,7 +20,7 @@ function CreateCajaForm({
         pathname: '/estudios',
         state: { fromCaja: true },
     };
-
+    const goBack = () => history.push('/caja/main');
     const [totalGrilla, setTotalGrilla] = useState(0.00);
 
     const selectEstudio = () => history.push(fromCajaLocation);
@@ -33,7 +33,7 @@ function CreateCajaForm({
                 tipo.text === movimiento.tipoMovimiento),
             medico: movimiento.medico ? movimiento.medico[0] : '',
         })),
-    }, history.goBack, destruirForm);
+    }, goBack, destruirForm);
 
     return (
         <Form

--- a/src/js/caja/components/create/CreateCajaForm.js
+++ b/src/js/caja/components/create/CreateCajaForm.js
@@ -14,14 +14,12 @@ function CreateCajaForm({
     estudioAsociado,
     asociarEstudio,
     destruirForm,
-    location,
+    montoTotal,
 }) {
     const fromCajaLocation = {
         pathname: '/estudios',
         state: { fromCaja: true },
     };
-
-    const montoAcumulado = location.state.montoAcumulado;
 
     const [totalGrilla, setTotalGrilla] = useState(0.00);
 
@@ -47,7 +45,7 @@ function CreateCajaForm({
               selectEstudio={ selectEstudio }
               asociarEstudio={ asociarEstudio }
               estudioAsociado={ estudioAsociado }
-              montoAcumulado={ montoAcumulado }
+              montoAcumulado={ montoTotal }
               totalGrilla={ totalGrilla }
             />
             <FieldArray
@@ -60,7 +58,7 @@ function CreateCajaForm({
     );
 }
 
-const { func, object } = PropTypes;
+const { func, object, string } = PropTypes;
 
 CreateCajaForm.propTypes = {
     createMovimiento: func.isRequired,
@@ -68,8 +66,8 @@ CreateCajaForm.propTypes = {
     history: object.isRequired,
     estudioAsociado: object.isRequired,
     asociarEstudio: func.isRequired,
-    location: object.isRequired,
     destruirForm: func.isRequired,
+    montoTotal: string.isRequired,
 };
 
 const CreateCajaFormRedux = reduxForm({
@@ -81,6 +79,7 @@ const CreateCajaFormRedux = reduxForm({
 function mapStateToProps(state) {
     return {
         estudioAsociado: state.cajaReducer.estudioAsociado,
+        montoTotal: state.cajaReducer.montoTotal,
     };
 }
 

--- a/src/js/caja/components/create/CreateMovimientoForm.js
+++ b/src/js/caja/components/create/CreateMovimientoForm.js
@@ -18,9 +18,7 @@ function CreateMovimientoForm({
         }
         const fieldsMovimiento = allValues.movimientos[idMovimiento];
 
-        // const medico = fieldsMovimiento.medico ? fieldsMovimiento.medico : [];
-
-        if ((value === undefined || Number(value) === 0) &&
+        if (value === undefined &&
             (fieldsMovimiento.concepto !== undefined || medico.length !== 0)) {
             return 'El monto no puede ser nulo';
         }

--- a/src/js/caja/components/create/CreateMovimientoForm.js
+++ b/src/js/caja/components/create/CreateMovimientoForm.js
@@ -2,17 +2,13 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { Field } from 'redux-form';
 import InputRF from '../../../utilities/InputRF';
-import AsyncTypeaheadRF from '../../../utilities/AsyncTypeaheadRF';
+import MedicoField from '../../../utilities/components/forms/MedicoField';
 
 function CreateMovimientoForm({
   tiposMovimientos,
   index,
-  opcionesMedicos,
-  isLoading,
-  onSearch,
-  renderMenu,
-  labelKey,
   idMovimiento,
+  medico,
 }) {
     const style = { padding: '0 0.5rem', margin: 0 };
 
@@ -22,7 +18,7 @@ function CreateMovimientoForm({
         }
         const fieldsMovimiento = allValues.movimientos[idMovimiento];
 
-        const medico = fieldsMovimiento.medico ? fieldsMovimiento.medico : [];
+        // const medico = fieldsMovimiento.medico ? fieldsMovimiento.medico : [];
 
         if (value === undefined &&
             (fieldsMovimiento.concepto !== undefined || medico.length !== 0)) {
@@ -34,17 +30,10 @@ function CreateMovimientoForm({
     return (
         <tr>
             <td style={ style }>
-                <Field
-                  name={ `${index}.medico` }
-                  component={ AsyncTypeaheadRF }
-                  placeholder='Nombre'
-                  type='text'
-                  options={ opcionesMedicos }
-                  onSearch={ onSearch }
-                  renderMenuItemChildren={ renderMenu }
-                  isLoading={ isLoading }
-                  labelKey={ labelKey }
-                  nullValue=''
+                <MedicoField
+                  nameField={ `${index}.medico` }
+                  type='actuante'
+                  medico={ medico }
                 />
             </td>
             <td style={ style }>
@@ -78,16 +67,12 @@ function CreateMovimientoForm({
     );
 }
 
-const { array, string, bool, func, number } = PropTypes;
+const { array, string, number } = PropTypes;
 
 CreateMovimientoForm.propTypes = {
     tiposMovimientos: array.isRequired,
     index: string.isRequired,
-    opcionesMedicos: array.isRequired,
-    isLoading: bool.isRequired,
-    renderMenu: func.isRequired,
-    onSearch: func.isRequired,
-    labelKey: func.isRequired,
+    medico: array.isRequired,
     idMovimiento: number.isRequired,
 };
 

--- a/src/js/caja/components/create/CreateMovimientoForm.js
+++ b/src/js/caja/components/create/CreateMovimientoForm.js
@@ -1,8 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Field, formValueSelector } from 'redux-form';
-import { connect } from 'react-redux';
-import { required, numberValue } from '../../../utilities/reduxFormValidators';
+import { Field } from 'redux-form';
 import InputRF from '../../../utilities/InputRF';
 import AsyncTypeaheadRF from '../../../utilities/AsyncTypeaheadRF';
 
@@ -14,9 +12,25 @@ function CreateMovimientoForm({
   onSearch,
   renderMenu,
   labelKey,
-  validate,
+  idMovimiento,
 }) {
     const style = { padding: '0 0.5rem', margin: 0 };
+
+    const controlMonto = (value, allValues) => {
+        if (!allValues.movimientos) {
+            return undefined;
+        }
+        const fieldsMovimiento = allValues.movimientos[idMovimiento];
+
+        const medico = fieldsMovimiento.medico ? fieldsMovimiento.medico : [];
+
+        if (value === undefined &&
+            (fieldsMovimiento.concepto !== undefined || medico.length !== 0)) {
+            return 'El monto no puede ser nulo';
+        }
+        return undefined;
+    };
+
     return (
         <tr>
             <td style={ style }>
@@ -46,9 +60,8 @@ function CreateMovimientoForm({
                   component={ InputRF }
                   componentClass='select'
                   selectOptions={ tiposMovimientos }
-                  validate={ validate && [required] }
-                  customErrorMsg='Debe seleccionar una opcion'
                   type='text'
+                  showNullValue={ false }
                 />
             </td>
             <td style={ { ...style, width: '15%' } }>
@@ -57,7 +70,7 @@ function CreateMovimientoForm({
                   placeholder='0.00'
                   component={ InputRF }
                   autoComplete='off'
-                  validate={ validate && [required, numberValue] }
+                  validate={ controlMonto }
                   nullValue=''
                 />
             </td>
@@ -65,7 +78,7 @@ function CreateMovimientoForm({
     );
 }
 
-const { array, string, bool, func } = PropTypes;
+const { array, string, bool, func, number } = PropTypes;
 
 CreateMovimientoForm.propTypes = {
     tiposMovimientos: array.isRequired,
@@ -75,24 +88,7 @@ CreateMovimientoForm.propTypes = {
     renderMenu: func.isRequired,
     onSearch: func.isRequired,
     labelKey: func.isRequired,
-    validate: bool.isRequired,
+    idMovimiento: number.isRequired,
 };
 
-const selector = formValueSelector('CreateCajaFormRedux');
-
-function mapStateToProps(state, ownProps) {
-    const { index } = ownProps;
-    const concepto = selector(state, `${index}.concepto`);
-    let medico = selector(state, `${index}.medico`);
-    const monto = selector(state, `${index}.monto`);
-    medico = (medico && Array.isArray(medico))
-        ? medico
-        : [];
-    const validate = concepto !== undefined || monto !== undefined || medico.length !== 0;
-    return {
-        validate,
-    };
-}
-
-export default
-    connect(mapStateToProps)(CreateMovimientoForm);
+export default CreateMovimientoForm;

--- a/src/js/caja/components/create/CreateMovimientoForm.js
+++ b/src/js/caja/components/create/CreateMovimientoForm.js
@@ -20,7 +20,7 @@ function CreateMovimientoForm({
 
         // const medico = fieldsMovimiento.medico ? fieldsMovimiento.medico : [];
 
-        if (value === undefined &&
+        if ((value === undefined || Number(value) === 0) &&
             (fieldsMovimiento.concepto !== undefined || medico.length !== 0)) {
             return 'El monto no puede ser nulo';
         }

--- a/src/js/caja/components/create/CreateMovimientosForm.js
+++ b/src/js/caja/components/create/CreateMovimientosForm.js
@@ -64,6 +64,7 @@ function CreateMovimientosForm({
                       tiposMovimientos={ descripcionMovimientos }
                       index={ movimiento }
                       key={ key }
+                      idMovimiento={ key }
                       opcionesMedicos={ medicos }
                       isLoading={ medicoApiLoading }
                       renderMenu={ renderMedicoMenuItem }

--- a/src/js/caja/components/create/CreateMovimientosForm.js
+++ b/src/js/caja/components/create/CreateMovimientosForm.js
@@ -65,6 +65,11 @@ function CreateMovimientosForm({
                       index={ movimiento }
                       key={ key }
                       idMovimiento={ key }
+                      medico={
+                        (movimiento.medico && Array.isArray(movimiento.medico))
+                        ? movimiento.medico
+                        : []
+                      }
                       opcionesMedicos={ medicos }
                       isLoading={ medicoApiLoading }
                       renderMenu={ renderMedicoMenuItem }

--- a/src/js/caja/components/create/CreateMovimientosForm.js
+++ b/src/js/caja/components/create/CreateMovimientosForm.js
@@ -3,37 +3,15 @@ import PropTypes from 'prop-types';
 import { Table } from 'react-bootstrap';
 import { formValueSelector } from 'redux-form';
 import { connect } from 'react-redux';
-import { FETCH_MEDICOS } from '../../../medico/actionTypes';
 import CreateMovimientoForm from './CreateMovimientoForm';
 import { getArray } from '../../../utilities/utilFunctions';
 
 function CreateMovimientosForm({
-    fetchMedicos,
-    medicos,
-    medicoApiLoading,
     setTotalGrilla,
     movimientos,
     fields,
     tiposMovimiento,
 }) {
-    const renderMedicoMenuItem = option => (
-        <div key={ option.id }>
-            { `${option.apellido}, ${option.nombre}` }
-        </div>
-    );
-
-    const medicosTypeaheadRenderFunc = (option) => {
-        if (!option.nombre || !option.apellido) {
-            return '-';
-        }
-
-        return `${option.apellido}, ${option.nombre}`;
-    };
-
-    const searchMedicos = (nombre) => {
-        fetchMedicos({ searchText: nombre });
-    };
-
     const descripcionMovimientos = tiposMovimiento.map(movimiento => movimiento.text);
 
     useEffect(() => {
@@ -66,12 +44,7 @@ function CreateMovimientosForm({
                       index={ movimiento }
                       key={ key }
                       idMovimiento={ key }
-                      medico={ getArray(movimiento.medico) }
-                      opcionesMedicos={ medicos }
-                      isLoading={ medicoApiLoading }
-                      renderMenu={ renderMedicoMenuItem }
-                      onSearch={ searchMedicos }
-                      labelKey={ medicosTypeaheadRenderFunc }
+                      medico={ getArray(movimientos[key].medico) }
                     />
                 ))}
             </tbody>
@@ -79,12 +52,9 @@ function CreateMovimientosForm({
     );
 }
 
-const { array, func, bool, object } = PropTypes;
+const { array, func, object } = PropTypes;
 
 CreateMovimientosForm.propTypes = {
-    fetchMedicos: func.isRequired,
-    medicos: array.isRequired,
-    medicoApiLoading: bool.isRequired,
     setTotalGrilla: func.isRequired,
     movimientos: array.isRequired,
     fields: object,
@@ -99,18 +69,9 @@ const selector = formValueSelector('CreateCajaFormRedux');
 
 function mapStateToProps(state) {
     return {
-        medicos: state.medicoReducer.medicos,
-        medicoApiLoading: state.medicoReducer.medicoApiLoading,
         movimientos: selector(state, 'movimientos'),
     };
 }
 
-function mapDispatchToProps(dispatch) {
-    return {
-        fetchMedicos: searchParam =>
-            dispatch({ type: FETCH_MEDICOS, searchParam }),
-    };
-}
-
 export default
-    connect(mapStateToProps, mapDispatchToProps)(CreateMovimientosForm);
+    connect(mapStateToProps, null)(CreateMovimientosForm);

--- a/src/js/caja/components/create/CreateMovimientosForm.js
+++ b/src/js/caja/components/create/CreateMovimientosForm.js
@@ -74,4 +74,4 @@ function mapStateToProps(state) {
 }
 
 export default
-    connect(mapStateToProps, null)(CreateMovimientosForm);
+    connect(mapStateToProps)(CreateMovimientosForm);

--- a/src/js/caja/components/create/CreateMovimientosForm.js
+++ b/src/js/caja/components/create/CreateMovimientosForm.js
@@ -5,6 +5,7 @@ import { formValueSelector } from 'redux-form';
 import { connect } from 'react-redux';
 import { FETCH_MEDICOS } from '../../../medico/actionTypes';
 import CreateMovimientoForm from './CreateMovimientoForm';
+import { getArray } from '../../../utilities/utilFunctions';
 
 function CreateMovimientosForm({
     fetchMedicos,
@@ -65,11 +66,7 @@ function CreateMovimientosForm({
                       index={ movimiento }
                       key={ key }
                       idMovimiento={ key }
-                      medico={
-                        (movimiento.medico && Array.isArray(movimiento.medico))
-                        ? movimiento.medico
-                        : []
-                      }
+                      medico={ getArray(movimiento.medico) }
                       opcionesMedicos={ medicos }
                       isLoading={ medicoApiLoading }
                       renderMenu={ renderMedicoMenuItem }

--- a/src/js/caja/components/create/HeaderCreateMovimientoCaja.js
+++ b/src/js/caja/components/create/HeaderCreateMovimientoCaja.js
@@ -6,7 +6,6 @@ import ViewAsociado from './ViewAsociado';
 
 function HeaderCreateMovimientoCaja({
     selectEstudio,
-    valid,
     asociarEstudio,
     estudioAsociado,
     montoAcumulado,
@@ -19,7 +18,6 @@ function HeaderCreateMovimientoCaja({
             <Col md={ 6 }>
                 <BotonesForm
                   selectEstudio={ selectEstudio }
-                  valid={ valid }
                   estudioAsociado={ estudioAsociado }
                   asociarEstudio={ asociarEstudio }
                   style={ style }
@@ -53,11 +51,10 @@ function HeaderCreateMovimientoCaja({
     );
 }
 
-const { func, object, bool, number } = PropTypes;
+const { func, object, number } = PropTypes;
 
 HeaderCreateMovimientoCaja.propTypes = {
     selectEstudio: func.isRequired,
-    valid: bool.isRequired,
     asociarEstudio: func.isRequired,
     estudioAsociado: object.isRequired,
     montoAcumulado: number.isRequired,

--- a/src/js/caja/components/create/HeaderCreateMovimientoCaja.js
+++ b/src/js/caja/components/create/HeaderCreateMovimientoCaja.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import { Col, Panel, Row } from 'react-bootstrap';
 import BotonesForm from './BotonesForm';
 import ViewAsociado from './ViewAsociado';
+import { round } from '../../../utilities/utilFunctions';
 
 function HeaderCreateMovimientoCaja({
     selectEstudio,
@@ -11,7 +12,7 @@ function HeaderCreateMovimientoCaja({
     montoAcumulado,
     totalGrilla,
 }) {
-    const totalGrillaView = Math.round(totalGrilla * 100) / 100 || 0.00;
+    const totalGrillaView = round(totalGrilla) || 0.00;
     const style = { marginTop: '20px', marginBottom: '20px' };
     return (
         <Row>
@@ -51,13 +52,13 @@ function HeaderCreateMovimientoCaja({
     );
 }
 
-const { func, object, number } = PropTypes;
+const { func, object, number, string } = PropTypes;
 
 HeaderCreateMovimientoCaja.propTypes = {
     selectEstudio: func.isRequired,
     asociarEstudio: func.isRequired,
     estudioAsociado: object.isRequired,
-    montoAcumulado: number.isRequired,
+    montoAcumulado: string.isRequired,
     totalGrilla: number.isRequired,
 };
 

--- a/src/js/caja/components/search/SearchCajaForm.js
+++ b/src/js/caja/components/search/SearchCajaForm.js
@@ -147,11 +147,9 @@ const SearchCajaFormReduxForm = reduxForm({
 const selector = formValueSelector('searchCaja');
 
 function mapStateToProps(state) {
-    let medicoActuante = selector(state, 'medicoActuante');
-    medicoActuante = getArray(medicoActuante);
+    const medicoActuante = getArray(selector(state, 'medicoActuante'));
 
-    let paciente = selector(state, 'paciente');
-    paciente = getArray(paciente);
+    const paciente = getArray(selector(state, 'paciente'));
 
     return {
         tiposMovimiento: [

--- a/src/js/caja/components/search/SearchCajaForm.js
+++ b/src/js/caja/components/search/SearchCajaForm.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { Field, reduxForm, formValueSelector, change } from 'redux-form';
 import { Row, Col, Button, Glyphicon, Form } from 'react-bootstrap';
+
 import InputRF from '../../../utilities/InputRF';
 import MedicoField from '../../../utilities/components/forms/MedicoField';
 import PacienteField from '../../../utilities/components/forms/PacienteField';
@@ -127,13 +128,13 @@ const { func, array, bool } = PropTypes;
 
 SearchCajaForm.propTypes = {
     handleSubmit: func.isRequired,
-    valid: bool.isRequired,
+    fetchMovimientosCaja: func.isRequired,
     closeModal: func.isRequired,
+    removeDate: func.isRequired,
+    valid: bool.isRequired,
     actuante: array,
     paciente: array,
     tiposMovimiento: array,
-    fetchMovimientosCaja: func.isRequired,
-    removeDate: func.isRequired,
 };
 
 const SearchCajaFormReduxForm = reduxForm({

--- a/src/js/caja/components/search/SearchCajaForm.js
+++ b/src/js/caja/components/search/SearchCajaForm.js
@@ -7,6 +7,7 @@ import InputRF from '../../../utilities/InputRF';
 import MedicoField from '../../../utilities/components/forms/MedicoField';
 import PacienteField from '../../../utilities/components/forms/PacienteField';
 import initialValues from '../../cajaSearchFormInitialState';
+import { getArray } from '../../../utilities/utilFunctions';
 
 function SearchCajaForm({
     actuante,
@@ -145,14 +146,10 @@ const selector = formValueSelector('searchCaja');
 
 function mapStateToProps(state) {
     let medicoActuante = selector(state, 'medicoActuante');
-    medicoActuante = (medicoActuante && Array.isArray(medicoActuante))
-            ? medicoActuante
-            : [];
+    medicoActuante = getArray(paciente);
 
     let paciente = selector(state, 'paciente');
-    paciente = (paciente && Array.isArray(paciente))
-            ? paciente
-            : [];
+    paciente = getArray(paciente);
 
     return {
         tiposMovimiento: [

--- a/src/js/caja/components/search/SearchCajaForm.js
+++ b/src/js/caja/components/search/SearchCajaForm.js
@@ -22,6 +22,7 @@ function SearchCajaForm({
 }) {
     const style = { marginTop: '2rem', cursor: 'pointer', padding: '1rem' };
     const booleanOptions = [{ text: 'Si', value: 'True' }, { text: 'No', value: 'False' }];
+
     return (
         <Form
           onSubmit={ handleSubmit((params) => { closeModal(); fetchMovimientosCaja(params); }) }
@@ -147,7 +148,7 @@ const selector = formValueSelector('searchCaja');
 
 function mapStateToProps(state) {
     let medicoActuante = selector(state, 'medicoActuante');
-    medicoActuante = getArray(paciente);
+    medicoActuante = getArray(medicoActuante);
 
     let paciente = selector(state, 'paciente');
     paciente = getArray(paciente);

--- a/src/js/caja/components/update/FormUpdate.js
+++ b/src/js/caja/components/update/FormUpdate.js
@@ -8,6 +8,7 @@ import { required } from '../../../utilities/reduxFormValidators';
 import InputRF from '../../../utilities/InputRF';
 import MedicoField from '../../../utilities/components/forms/MedicoField';
 import { tiposMovimiento } from '../../../utilities/generalUtilities';
+import { getArray } from '../../../utilities/utilFunctions';
 
 function FormUpdate({ medico, updateForm, movimiento }) {
     useEffect(() => {
@@ -65,9 +66,7 @@ FormUpdate.propTypes = {
 
 function mapStateToProps(state) {
     let medico = selector(state, 'medico');
-    medico = (medico && Array.isArray(medico))
-            ? medico
-            : [];
+    medico = getArray(medico);
 
     return { medico };
 }

--- a/src/js/caja/components/update/FormUpdate.js
+++ b/src/js/caja/components/update/FormUpdate.js
@@ -30,6 +30,7 @@ function FormUpdate({ medico, updateForm, movimiento }) {
                   selectionValue='value'
                   renderOptionHandler={ opcion => opcion.text }
                   optionKey='text'
+                  showNullValue={ false }
                 />
             </Col>
             <Col md={ 4 }>

--- a/src/js/caja/components/update/FormUpdate.js
+++ b/src/js/caja/components/update/FormUpdate.js
@@ -65,8 +65,7 @@ FormUpdate.propTypes = {
 };
 
 function mapStateToProps(state) {
-    let medico = selector(state, 'medico');
-    medico = getArray(medico);
+    const medico = getArray(selector(state, 'medico'));
 
     return { medico };
 }

--- a/src/js/caja/components/update/ModalUpdate.js
+++ b/src/js/caja/components/update/ModalUpdate.js
@@ -48,7 +48,7 @@ ModalUpdate.propTypes = {
     updateMovimiento: func.isRequired,
 };
 
-const UpdateCajaFormRedux = reduxForm({ // ver
+const UpdateCajaFormRedux = reduxForm({
     form: 'UpdateCajaFormRedux',
     destroyOnUnmount: false,
     enableReinitialize: true,

--- a/src/js/utilities/InputRF.js
+++ b/src/js/utilities/InputRF.js
@@ -26,6 +26,7 @@ class InputRF extends React.Component {
             // this is the key to be used for tracking repeated options
             optionKey,
             nullValue = null,
+            showNullValue = true,
             ...props
         } = this.props;
         let { componentClass } = this.props;
@@ -78,7 +79,10 @@ class InputRF extends React.Component {
                                 <option key={ key } value={ value }>{optionDisplay}</option>
                             );
                         });
-                        options.unshift(<option key={ uuidv1() } value={ nullValue }>--</option>);
+                        if (showNullValue) {
+                            options.unshift(
+                                <option key={ uuidv1() } value={ nullValue }>--</option>);
+                        }
                         return options;
                     })()
                     }
@@ -114,6 +118,7 @@ InputRF.propTypes = {
     customErrorMsg: string,
     optionKey: string,
     nullValue: string,
+    showNullValue: bool,
 };
 
 export default InputRF;

--- a/src/js/utilities/utilFunctions.js
+++ b/src/js/utilities/utilFunctions.js
@@ -1,1 +1,8 @@
 export const round = number => Math.round(number * 100) / 100;
+
+export const getArray = (dato) => {
+    if (dato && Array.isArray(dato)) {
+        return dato;
+    }
+    return [];
+};


### PR DESCRIPTION
# Caja arreglar errores

## Cambios en esta PR
- El field tipo ya no puede ser nulo en crear y en update movimientos.
- Se elimina el valid de crear movimientos.
- Se utiliza medifoField de utilities para crear movimientos.
- Se crea una función para validar los montos en crear movimientos.
- tipoMovimientos se obtiene de utilities.
- El formulario de crear movimientos se destruye una vez la api conteste de forma afirmativa.
- Al modificar movimientos se actualizan los montos.
- Solo se muestra médico asociado y no el del estudio en caja main.
- Imprimir caja funciona con los filtros de "hoy".
- Se arregla field de médicos que evitaban que se vean si se iban de la pagina.

## Estado de la PR
Lista